### PR TITLE
Add more feedback to automerge failures

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -18,10 +18,20 @@ jobs:
     - name: Check for blacklisted edits
       run: |
         #!/bin/bash
-        diffs=$(git diff --name-only $(git rev-parse --abbrev-ref HEAD) $(git merge-base $(git rev-parse --abbrev-ref HEAD) origin/main))
-        if grep -iq .github <<<$diffs; then
+        head=$(git rev-parse --abbrev-ref HEAD)
+        echo - head: $head
+        main=$(git merge-base $head origin/main)
+        echo - main: $main
+        diff_cmd="git diff --name-only $head $main"
+        echo - diff_cmd: $diff_cmd
+        diffs=$($diff_cmd)
+        echo '- diff_cmd result (below):'
+        echo $diffs
+        echo '- forbidden edits (below):'
+        if grep -i '\.github' <<<$diffs; then
           exit 1;
-        else exit 0;
+        else
+          exit 0;
         fi
   automerge:  # https://github.com/marketplace/actions/merge-pull-requests-automerge-action
     needs: checkEdits


### PR DESCRIPTION
Automerge is detecting false positives for edits to files named .github anytime I try to change anything. Increased feedback will help find the cause of false positives.

For example, PRs #114 #115 #116 failed due to false positives.

This time (obviously) I am changing .github/workflows/automerge.yml on purpose, but the other times I was not.