### PR TITLE
Check rail-layer for signals when undoing landfill

### DIFF
--- a/lua/landfill undo.lua
+++ b/lua/landfill undo.lua
@@ -24,7 +24,7 @@ local function go2(gps)
   local new_water,counts = {},{}
   for _,t in pairs(surface.find_tiles_filtered{area=bb, name="landfill"}) do
     local pos = t.position
-    if surface.count_entities_filtered{collision_mask={"ghost-layer","object-layer","player-layer"}, area={left_top=pos, right_bottom={pos.x+1,pos.y+1}}} > 0 then
+    if surface.count_entities_filtered{collision_mask={"ghost-layer","object-layer","player-layer","rail-layer"}, area={left_top=pos, right_bottom={pos.x+1,pos.y+1}}} > 0 then
       count_in(counts, "skipped")
     else
       new_water[#new_water+1] = { position=pos, name="" }


### PR DESCRIPTION
Checking object-layer for collisions was sufficient to find tracks, but
not signals, which only collide with rail-layer. Landfill under signals
was being destroyed, destroying the signal if the tile changed back to
water. Adding rail-layer to the collision_mask fixes this.