### PR TITLE
Add a script to find and ping all entities that have zero finished products

### DIFF
--- a/lua/find entities with zero finished products.lua
+++ b/lua/find entities with zero finished products.lua
@@ -1,0 +1,25 @@
+/silent-command 
+--[[
+Find and ping all entities that have zero finished products
+]]
+local found_ents = {} 
+local ents = {"assembling-machine-1", "assembling-machine-2", "assembling-machine-3", "stone-furnace", "steel-furnace", "electric-furnace", "chemical-plant", "oil-refinery", "centrifuge"} 
+for _, entity in pairs(game.player.surface.find_entities_filtered({name = ents})) do 
+    if entity.products_finished  == 0 then 
+      if not found_ents[entity.name] then found_ents[entity.name] = {} end 
+        table.insert(found_ents[entity.name], {x = entity.position.x, y = entity.position.y}) 
+    end 
+end 
+
+if not next(found_ents) then 
+  game.print("No entities with zero finished products found!") 
+else 
+  game.print("Entities with zero products finished: ") 
+  for loc_name, cord_sets in pairs(found_ents) do 
+    local x = ""
+    for _, cords in pairs(cord_sets) do 
+      x = x .. " [gps="..cords.x..","..cords.y.."]" 
+    end 
+    game.print("[img=item."..loc_name.."]"..x.."\n") 
+  end 
+end 


### PR DESCRIPTION
Adds a script  that finds & pings all defined entities that have zero finished products.
Very useful to check if all builds work correctly.
We had a lot of assemblers not working due to their input inserters being stuck with a piece of stone or fish.

Chat output is seperated for each found entity.

Example:
![image](https://github.com/combe15/factorio-whiteboard/assets/62474527/338eff19-0039-406c-9869-c9fe4901e8a2)